### PR TITLE
commented out EasyMercurial, MayaVi, and NetworkX in CHECKS

### DIFF
--- a/setup/swc-installation-test-2.py
+++ b/setup/swc-installation-test-2.py
@@ -72,7 +72,7 @@ CHECKS = [
     'git',
     'hg',              # Command line tool
     #'mercurial',       # Python package
-    'EasyMercurial',
+    #'EasyMercurial',
 # Build tools and packaging
     'make',
     'virtual-pypi-installer',
@@ -97,8 +97,8 @@ CHECKS = [
     'pandas',
     'sympy',
     'Cython',
-    'networkx',
-    'mayavi.mlab',
+    #'networkx',
+    #'mayavi.mlab',
     ]
 
 CHECKER = {}


### PR DESCRIPTION
I went through the setup steps on a clean account on my Mac, and `swc-installation-test-2.py` failed when checking for EasyMercurial, MayaVi, and NetworkX. I don't think that the students will need these for this workshop, so I went ahead and commented them out in the the `CHECKS` list. This will bypass the checks for these installations. See the links below for more info.

https://github.com/swcarpentry/workshop-template/blob/gh-pages/CUSTOMIZATION.md#home-page-setup
https://github.com/swcarpentry/workshop-template/issues/136
